### PR TITLE
Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,16 @@ env:
     - TOXENV=pypy-django18-sqlite
     - TOXENV=pypy3-django18-pg
     - TOXENV=pypy3-django18-sqlite
+    - TOXENV=py27-django110-pg
+    - TOXENV=py27-django110-sqlite
+    - TOXENV=py33-django110-pg
+    - TOXENV=py33-django110-sqlite
+    - TOXENV=py34-django110-pg
+    - TOXENV=py34-django110-sqlite
+    - TOXENV=pypy-django110-pg
+    - TOXENV=pypy-django110-sqlite
+    - TOXENV=pypy3-django110-pg
+    - TOXENV=pypy3-django110-sqlite
     - TOXENV=py27-djangotrunk-pg
     - TOXENV=py27-djangotrunk-sqlite
     - TOXENV=py34-djangotrunk-pg
@@ -25,8 +35,10 @@ env:
     - TOXENV=pypy-djangotrunk-pg
     - TOXENV=pypy-djangotrunk-sqlite
     - TOXENV=py27-django18-mysql
+    - TOXENV=py27-django110-mysql
     - TOXENV=py27-djangotrunk-mysql
     - TOXENV=pypy-django18-mysql
+    - TOXENV=pypy-django110-mysql
     - TOXENV=pypy-djangotrunk-mysql
     - TOXENV=flake8
     - TOXENV=docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,49 @@
 language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "pypy"
 
 env:
   global:
     - DJF_USERNAME=postgres
   # Keep this list up to date using `tox -l`
   matrix:
-    - TOXENV=py27-django18-pg
-    - TOXENV=py27-django18-sqlite
-    - TOXENV=py33-django18-pg
-    - TOXENV=py33-django18-sqlite
-    - TOXENV=py34-django18-pg
-    - TOXENV=py34-django18-sqlite
+    - TOXENV=pypy-django18-mysql
     - TOXENV=pypy-django18-pg
     - TOXENV=pypy-django18-sqlite
-    - TOXENV=pypy3-django18-pg
-    - TOXENV=pypy3-django18-sqlite
-    - TOXENV=py27-django110-pg
-    - TOXENV=py27-django110-sqlite
-    - TOXENV=py33-django110-pg
-    - TOXENV=py33-django110-sqlite
-    - TOXENV=py34-django110-pg
-    - TOXENV=py34-django110-sqlite
+    - TOXENV=pypy-django110-mysql
     - TOXENV=pypy-django110-pg
     - TOXENV=pypy-django110-sqlite
-    - TOXENV=pypy3-django110-pg
-    - TOXENV=pypy3-django110-sqlite
-    - TOXENV=py27-djangotrunk-pg
-    - TOXENV=py27-djangotrunk-sqlite
-    - TOXENV=py34-djangotrunk-pg
-    - TOXENV=py34-djangotrunk-sqlite
-    # Travis doesn't have Python 3.5 available yet.
-    # - TOXENV=py35-djangotrunk-pg
-    # - TOXENV=py35-djangotrunk-sqlite
-    - TOXENV=pypy-djangotrunk-pg
-    - TOXENV=pypy-djangotrunk-sqlite
     - TOXENV=py27-django18-mysql
+    - TOXENV=py27-django18-pg
+    - TOXENV=py27-django18-sqlite
     - TOXENV=py27-django110-mysql
-    - TOXENV=py27-djangotrunk-mysql
-    - TOXENV=pypy-django18-mysql
-    - TOXENV=pypy-django110-mysql
-    - TOXENV=pypy-djangotrunk-mysql
+    - TOXENV=py27-django110-pg
+    - TOXENV=py27-django110-sqlite
+    - TOXENV=py33-django18-pg
+    - TOXENV=py33-django18-mysql
+    - TOXENV=py33-django18-sqlite
+    - TOXENV=py33-django110-pg
+    - TOXENV=py33-django110-sqlite
+    - TOXENV=py33-django110-mysql
+    - TOXENV=py34-django18-pg
+    - TOXENV=py34-django18-sqlite
+    - TOXENV=py34-django18-mysql
+    - TOXENV=py34-django110-pg
+    - TOXENV=py34-django110-sqlite
+    - TOXENV=py34-django110-mysql
+    - TOXENV=py34-djangotrunk-pg
+    - TOXENV=py34-djangotrunk-mysql
+    - TOXENV=py34-djangotrunk-sqlite
+    - TOXENV=py35-djangotrunk-pg
+    - TOXENV=py35-djangotrunk-sqlite
+    - TOXENV=py35-djangotrunk-mysql
+    - TOXENV=py36-djangotrunk-pg
+    - TOXENV=py36-djangotrunk-sqlite
+    - TOXENV=py36-djangotrunk-mysql
     - TOXENV=flake8
     - TOXENV=docs
 

--- a/fernet_fields/fields.py
+++ b/fernet_fields/fields.py
@@ -71,6 +71,15 @@ class EncryptedField(models.Field):
             retval = self.fernet.encrypt(force_bytes(value))
             return connection.Database.Binary(retval)
 
+    def get_lookup(self, lookup_name):
+        if lookup_name == 'isnull':
+            return super(EncryptedField, self).get_lookup(lookup_name)
+        else:
+            raise FieldError(
+                "%s '%s' does not support lookups."
+                % (self.__class__.__name__, self.name)
+            )
+
     def get_prep_lookup(self, lookup_type, value):
         if lookup_type == 'isnull':
             return super(EncryptedField, self).get_prep_lookup(lookup_type,

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     {pypy,pypy3}-pg: psycopg2cffi==2.6.1
     mysql: MySQL-python==1.2.5
     # Older PyPy versions (and all released PyPy3 versions) don't work with cryptography 1.0
-    py{26,27,33,34,35}: cryptography==1.0.1
+    py{26,27,33,34,35}: cryptography==1.7.2
     py{py,py3}: cryptography==0.9.3
 setenv =
     sqlite: DJANGO_SETTINGS_MODULE = fernet_fields.test.settings.sqlite

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist =
-    py{27,33,34,py,py3}-django18-{pg,sqlite},
-    py{27,33,34,py,py3}-django110-{pg,sqlite},
-    py{27,34,35,py}-djangotrunk-{pg,sqlite},
-    py{27,py}-django{18,trunk}-mysql,
+    py{py,27,34,35,36}-django18-{pg,sqlite,mysql},
+    py{py,27,34,35,36}-django110-{pg,sqlite,mysql},
+    py{34,35,36}-djangotrunk-{pg,sqlite},
     flake8,
     docs
 
@@ -16,12 +15,12 @@ deps =
     django18: Django>=1.8,<1.9
     django110: Django>=1.10,<1.11
     djangotrunk: https://github.com/django/django/tarball/master
-    py{26,27,33,34,35}-pg: psycopg2==2.6
-    {pypy,pypy3}-pg: psycopg2cffi==2.6.1
-    mysql: MySQL-python==1.2.5
+    py{26,27,34,35,36}-pg: psycopg2==2.6
+    mysql: mysqlclient==1.3.9
+    py{26,27,34,35,36}: cryptography==1.7.2
     # Older PyPy versions (and all released PyPy3 versions) don't work with cryptography 1.0
-    py{26,27,33,34,35}: cryptography==1.7.2
-    py{py,py3}: cryptography==0.9.3
+    pypy: cryptography==0.9.3
+    pypy-pg: psycopg2cffi==2.6.1
 setenv =
     sqlite: DJANGO_SETTINGS_MODULE = fernet_fields.test.settings.sqlite
     pg: DJANGO_SETTINGS_MODULE = fernet_fields.test.settings.pg

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py{27,33,34,py,py3}-django18-{pg,sqlite},
+    py{27,33,34,py,py3}-django110-{pg,sqlite},
     py{27,34,35,py}-djangotrunk-{pg,sqlite},
     py{27,py}-django{18,trunk}-mysql,
     flake8,
@@ -13,6 +14,7 @@ deps =
     py==1.4.30
     coverage==3.7.1
     django18: Django>=1.8,<1.9
+    django110: Django>=1.10,<1.11
     djangotrunk: https://github.com/django/django/tarball/master
     py{26,27,33,34,35}-pg: psycopg2==2.6
     {pypy,pypy3}-pg: psycopg2cffi==2.6.1


### PR DESCRIPTION
Adds support for Django 1.10 and above.

Had to upgrade cryptography to be able to run tox on debian jessie.