### PR TITLE
Update the README with supported versions of python.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ django-fernet-fields
 `cryptography`_ library.
 
 ``django-fernet-fields`` supports `Django`_ 1.8.2 and later on Python 2.7, 3.3,
-3.4, pypy, and pypy3.
+3.4, 3.5, 3.6, pypy, and pypy3.
 
 Only PostgreSQL, SQLite, and MySQL are tested, but any Django database backend
 with support for ``BinaryField`` should work.


### PR DESCRIPTION
This PR resolves #6 by mentioning that python 3.5 and python 3.6 are supported.