### PR TITLE
RemovedInDjango30Warning: Removed explicit context argument.

### DIFF
--- a/fernet_fields/fields.py
+++ b/fernet_fields/fields.py
@@ -71,7 +71,7 @@ class EncryptedField(models.Field):
             retval = self.fernet.encrypt(force_bytes(value))
             return connection.Database.Binary(retval)
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection, *args):
         if value is not None:
             value = bytes(value)
             return self.to_python(force_text(self.fernet.decrypt(value)))


### PR DESCRIPTION
This removes the explicit context argument which is no longer supported in Django >= 3.

Fixes issue #11 .