### PR TITLE
Update classifiers to include python 3.6 in the supported versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Framework :: Django',


### PR DESCRIPTION
I noticed that py36 is supported by the library but not officially listed in the classifiers! This PR updates the classifiers to include py36.