### PR TITLE
updating python versions to match README.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -60,8 +60,8 @@ versions) and generate a coverage report in the ``htmlcov/`` directory::
 
     make test
 
-This requires that you have ``python2.7``, ``python3.3``, ``python3.4``,
-``pypy``, and ``pypy3`` binaries on your system's shell path.
+This requires that you have ``python2.7``, ``python3.5``, ``python3.6``,
+``python3.7``, ``pypy``, and ``pypy3`` binaries on your system's shell path.
 
 To install PostgreSQL on Debian-based systems::
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,8 +11,8 @@ Welcome to django-fernet-fields!
 Prerequisites
 -------------
 
-``django-fernet-fields`` supports `Django`_ 1.8.2 and later on Python 2.7, 3.3,
-3.4, pypy, and pypy3.
+``django-fernet-fields`` supports `Django`_ 1.8.2 and later on Python 2.7, 3.5,
+3.6, 3.7, pypy, and pypy3.
 
 Only PostgreSQL, SQLite, and MySQL are tested, but any Django database backend
 with support for ``BinaryField`` should work.


### PR DESCRIPTION
Trivial fix to make README.rst and these files consistent.

![image](https://user-images.githubusercontent.com/1270274/60134234-0bfefb00-976d-11e9-95f7-92ceec41b4c3.png)
