### PR TITLE
Update signature for Django 3

### DIFF
--- a/fernet_fields/fields.py
+++ b/fernet_fields/fields.py
@@ -71,7 +71,7 @@ class EncryptedField(models.Field):
             retval = self.fernet.encrypt(force_bytes(value))
             return connection.Database.Binary(retval)
 
-    def from_db_value(self, value, expression, connection, *args):
+    def from_db_value(self, value, expression, connection, context=None):
         if value is not None:
             value = bytes(value)
             return self.to_python(force_text(self.fernet.decrypt(value)))


### PR DESCRIPTION
Upgrading Django from 2.2 to 3.0.5 and getting this error when I try the built in admin for a model with encrypted fields

`TypeError: from_db_value() missing 1 required positional argument: 'context'`

Looks like the method signature was updated but someone already has a fix: https://luc.lino-framework.org/blog/2019/1128.html