### PR TITLE
Replace force_text with force_str for django >= 3

### DIFF
--- a/fernet_fields/fields.py
+++ b/fernet_fields/fields.py
@@ -1,10 +1,12 @@
 from cryptography.fernet import Fernet, MultiFernet
+
 from django.conf import settings
 from django.core.exceptions import FieldError, ImproperlyConfigured
 from django.db import models
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes
 from django.utils.functional import cached_property
 
+from .utils import force_text
 from . import hkdf
 
 

--- a/fernet_fields/test/test_fields.py
+++ b/fernet_fields/test/test_fields.py
@@ -1,12 +1,15 @@
-from cryptography.fernet import Fernet
 from datetime import date, datetime
+
+import pytest
+
+from cryptography.fernet import Fernet
+import fernet_fields as fields
 
 from django.core.exceptions import FieldError, ImproperlyConfigured
 from django.db import connection, models as dj_models
-from django.utils.encoding import force_bytes, force_text
-import pytest
+from django.utils.encoding import force_bytes
 
-import fernet_fields as fields
+from .utils import force_text
 from . import models
 
 

--- a/fernet_fields/test/test_fields.py
+++ b/fernet_fields/test/test_fields.py
@@ -1,15 +1,15 @@
 from datetime import date, datetime
 
 import pytest
-
 from cryptography.fernet import Fernet
-import fernet_fields as fields
 
 from django.core.exceptions import FieldError, ImproperlyConfigured
 from django.db import connection, models as dj_models
 from django.utils.encoding import force_bytes
 
-from .utils import force_text
+import fernet_fields as fields
+from fernet_fields.utils import force_text
+
 from . import models
 
 

--- a/fernet_fields/utils.py
+++ b/fernet_fields/utils.py
@@ -1,8 +1,7 @@
-import django
+from django import VERSION as DJANGO_VERSION
 
 
-DJANGO_VERSION = django.get_version().split('.')
-if DJANGO_VERSION[0] < "3":
+if DJANGO_VERSION[0] < 3:
     from django.utils.encoding import force_text
 else:
     from django.utils.encoding import force_str as force_text

--- a/fernet_fields/utils.py
+++ b/fernet_fields/utils.py
@@ -1,0 +1,8 @@
+import django
+
+
+DJANGO_VERSION = django.get_version().split('.')
+if DJANGO_VERSION[0] < "3":
+    from django.utils.encoding import force_text
+else:
+    from django.utils.encoding import force_str as force_text

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py36-{docs,flake8},
     py{27,35,36,37,py}-django111-{pg,sqlite},
-    py{35,36,37}-{django21,django22,djangolatest}-{pg,sqlite},
+    py{35,36,37}-{django21,django22,django30,djangolatest}-{pg,sqlite},
     flake8,
     docs
 
@@ -20,7 +20,8 @@ deps =
     django111: Django>=1.11,<2
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
-    djangolatest: Django>=2.2
+    django30: Django>=3.0,<3.1
+    djangolatest: Django>=3.0
 
     # Older PyPy versions (and all released PyPy3 versions) don't work with cryptography 1.0
     py{py,py3}: cryptography<1


### PR DESCRIPTION
Closes #22.

Since Django 3.0, `force_text` helper was declared deprecated.

From its definition, it seems that will be replaced with `force_str`
https://docs.djangoproject.com/en/3.0/_modules/django/utils/encoding/#force_text