### PR TITLE
Fix derive_fernet_key docstring bits/bytes confusion

### DIFF
--- a/fernet_fields/hkdf.py
+++ b/fernet_fields/hkdf.py
@@ -12,7 +12,7 @@ salt = b'django-fernet-fields-hkdf-salt'
 
 
 def derive_fernet_key(input_key):
-    """Derive a 32-bit b64-encoded Fernet key from arbitrary input key."""
+    """Derive a 32-byte (256-bit) b64-encoded Fernet key from arbitrary input key."""
     hkdf = HKDF(
         algorithm=hashes.SHA256(),
         length=32,


### PR DESCRIPTION
The Fernet key has 32 bytes of randomness, not bits.